### PR TITLE
Fix invalid volume mount for canasta-config in web deployment

### DIFF
--- a/Kubernetes/web.yaml
+++ b/Kubernetes/web.yaml
@@ -63,7 +63,6 @@ spec:
           subPath: ./skins
         - mountPath: /mediawiki/config
           name: canasta-config
-          subPath: ./config
         - mountPath: /mediawiki/settings
           name: canasta-settings
         - mountPath: /mediawiki/images


### PR DESCRIPTION
The web pod was failing to start because of an erroneous subPath in the canasta-config volume mount.

The ConfigMap does not contain a subdirectory named config, rendering subPath: ./config invalid. I have removed this line to ensure the configuration files are mounted correctly to /mediawiki/config.